### PR TITLE
fixed units attributes and added tzone attributes as GMT in common.c

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -123,7 +123,8 @@ static void setdatetimeclass(SEXP sxp) {
 }
 
 
-static SEXP UnitsSymbol = NULL;
+static SEXP R_UnitsSymbol = NULL;
+static SEXP R_TzSymbol = NULL;
 
 
 /* for timespan, minute, second */
@@ -131,12 +132,23 @@ SEXP setdifftimeclass(SEXP sxp, char* units) {
   SEXP difftimeclass= PROTECT(allocVector(STRSXP, 1));
   SET_STRING_ELT(difftimeclass, 0, mkChar("difftime"));
   setAttrib(sxp, R_ClassSymbol, difftimeclass);
-  if (UnitsSymbol == NULL) UnitsSymbol = install("units");
-  setAttrib(sxp, UnitsSymbol, mkChar(units));
-  UNPROTECT(1);
+  if (R_UnitsSymbol == NULL) R_UnitsSymbol = install("units");
+  SEXP difftimeunits= PROTECT(allocVector(STRSXP, 1));
+  SET_STRING_ELT(difftimeunits, 0, mkChar(units));
+  setAttrib(sxp, R_UnitsSymbol, difftimeunits);
+  UNPROTECT(2);
   return sxp;
 }
 
+/* for setting timezone */
+void settimezone(SEXP sxp, char* tzone) {
+  SEXP timezone= PROTECT(allocVector(STRSXP, 1));
+  SET_STRING_ELT(timezone, 0, mkChar(tzone));
+  if (R_TzSymbol == NULL) R_TzSymbol = install("tzone");
+  setAttrib(sxp, R_TzSymbol, timezone);
+  UNPROTECT(1);
+  //return sxp;
+}
 /* for date,month */
 SEXP setdateclass(SEXP sxp) {
   SEXP difftimeclass= PROTECT(allocVector(STRSXP, 1));
@@ -475,6 +487,7 @@ static SEXP from_datetime_kobject(K x) {
       NUMERIC_POINTER(result)[i]= (kF(x)[i] + 10957) * 86400;
   }
   setdatetimeclass(result);
+  settimezone(result,"GMT");
   return result;
 }
 

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -62,9 +62,11 @@ test_that("kdb types to R types", {
   expect_is(date, "Date")
   expect_equal(date, as.Date('2015-01-03'))
   
+  # we do not set the timezone attribute that is GMT on kdb unless explicitely set otherwise
   datetime <- testKdbToRType(h, '2006.07.21T09:13:39')
   expect_is(datetime, "POSIXt")
-  expect_equal(datetime, as.POSIXct('2006-07-21 09:13:39'))
+  rdatetime <- as.POSIXct('2006-07-21 09:13:39', tz='GMT')
+  expect_equal(datetime, rdatetime)
   
   timespan <- testKdbToRType(h, '12:00:00.000000000')
   expect_is(timespan, "difftime")
@@ -135,8 +137,7 @@ test_that("kdb types to R types", {
 # test R -> kdb
 test_that("R types to kdb types", {
   h <- skip_unless_has_test_db()
-  remoteCheckFunc <-
-    '`cc set {show"type is ",string type x;`tmp set x;`okType`okValue!(type[x]~y;x~z)}'
+  remoteCheckFunc <- '`cc set {show"type is ",string type x;`tmp set x;`okType`okValue!(type[x]~y;x~z)}'
   execute(h, remoteCheckFunc)
   int <- execute(h, 'cc[;6h;(),1i]', 1L)   # R doesn't have scalars
   expect_equal(int, c(okType = TRUE, okValue = TRUE))
@@ -152,8 +153,7 @@ test_that("R types to kdb types", {
   expect_equal(unamedL2, c(okType = TRUE, okValue = TRUE))
   namedVector <- execute(h, 'cc[;99h;`a`b!1 2f]', c(a = 1., b = 2.))
   expect_equal(namedVector, c(okType = TRUE, okValue = TRUE))
-  namedList <-
-    execute(h, 'cc[;99h;`a`b!((),1.;(),2.)]', list(a = 1., b = 2.))
+  namedList <- execute(h, 'cc[;99h;`a`b!((),1.;(),2.)]', list(a = 1., b = 2.))
   expect_equal(namedList, c(okType = TRUE, okValue = TRUE))
   
 })


### PR DESCRIPTION
Not too sure how datetime conversion should be handled, but if we a tzone attribute should be created in the returned POSIXct.
This fixes 2 tests, but some are still failing (is that expected ?) 