### PR TITLE
Movement of guid conversion away from kdb server + test addition

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -249,9 +249,9 @@ static SEXP from_byte_kobject(K x) {
 
 static SEXP from_guid_kobject(K x) {
   K y=ktn(KC,37);
-  y->n=36;
   G*gv=kG(x);
   sprintf(kC(y),"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",gv[ 0],gv[ 1],gv[ 2],gv[ 3],gv[ 4],gv[ 5],gv[ 6],gv[ 7],gv[ 8],gv[ 9],gv[10],gv[11],gv[12],gv[13],gv[14],gv[15]);
+  y->n=36;
   SEXP r= from_any_kobject(y);
   r0(y);
   return r;

--- a/src/common.c
+++ b/src/common.c
@@ -249,7 +249,9 @@ static SEXP from_byte_kobject(K x) {
 
 // TODO: convert guids locally using something like rawToChar()
 static SEXP from_guid_kobject(K x) {
-  K y= k(kx_connection, "string", r1(x), (K) 0);
+  K y=ktn(KC,36);
+  G*gv=kG(x);
+  sprintf(kC(y),"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",gv[ 0],gv[ 1],gv[ 2],gv[ 3],gv[ 4],gv[ 5],gv[ 6],gv[ 7],gv[ 8],gv[ 9],gv[10],gv[11],gv[12],gv[13],gv[14],gv[15]);
   SEXP r= from_any_kobject(y);
   r0(y);
   return r;

--- a/src/common.c
+++ b/src/common.c
@@ -247,9 +247,9 @@ static SEXP from_byte_kobject(K x) {
   return result;
 }
 
-// TODO: convert guids locally using something like rawToChar()
 static SEXP from_guid_kobject(K x) {
-  K y=ktn(KC,36);
+  K y=ktn(KC,37);
+  y->n=36;
   G*gv=kG(x);
   sprintf(kC(y),"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",gv[ 0],gv[ 1],gv[ 2],gv[ 3],gv[ 4],gv[ 5],gv[ 6],gv[ 7],gv[ 8],gv[ 9],gv[10],gv[11],gv[12],gv[13],gv[14],gv[15]);
   SEXP r= from_any_kobject(y);

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -17,6 +17,10 @@ test_that("kdb types to R types", {
   bool <- testKdbToRType(h, '1b')
   expect_is(bool, "logical")
   expect_true(bool)
+
+  guid <- testKdbToRType(h,'"G"$"f988c316-d1ec-6541-ee4c-44af6b5fc747"')
+  expect_is(guid, "character")
+  expect_equal(guid,'f988c316-d1ec-6541-ee4c-44af6b5fc747')
   
   byte <- testKdbToRType(h, '0x26')
   expect_is(byte, "raw")


### PR DESCRIPTION
* This modification changes the method by which guids are converted to K objects to move away from the use of kdb+ calls
* A test for this type has also been incorporated, this was missing previously