### PR TITLE
Ubuntu hardening patch

### DIFF
--- a/src/rkdb.c
+++ b/src/rkdb.c
@@ -81,7 +81,7 @@ SEXP kx_r_open_connection(SEXP whence) {
                   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buf, 256, NULL);
     error(buf);
 #else
-    error(strerror(errno));
+    error("%s", strerror(errno));
 #endif
   }
   return ScalarInteger(connection);


### PR DESCRIPTION
Fixes the error on Ubuntu 22.04
```
gcc -I"/usr/share/R/include" -DNDEBUG      -D_GNU_SOURCE -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-Kaw86j/r-base-4.4.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -c rkdb.c -o rkdb.o
rkdb.c: In function ‘kx_r_open_connection’:
rkdb.c:84:5: error: format not a string literal and no format arguments [-Werror=format-security]
   84 |     error(strerror(errno));
      |     ^~~~~
cc1: some warnings being treated as errors
make: *** [/usr/lib/R/etc/Makeconf:195: rkdb.o] Error 1
ERROR: compilation failed for package ‘rkdb’
```