### PR TITLE
fix gcc compile warning/error

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -461,7 +461,7 @@ static SEXP from_table_kobject(K x) {
 
 static K guid_2_char(G*gv){
     K y= ktn(KC,37);
-    sprintf(kC(y),"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",gv[ 0],gv[ 1],gv[ 2],gv[ 3],gv[ 4],gv[ 5],gv[ 6],gv[ 7],gv[ 8],gv[ 9],gv[10],gv[11],gv[12],gv[13],gv[14],gv[15]);
+    sprintf((char*)kC(y),"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",gv[ 0],gv[ 1],gv[ 2],gv[ 3],gv[ 4],gv[ 5],gv[ 6],gv[ 7],gv[ 8],gv[ 9],gv[10],gv[11],gv[12],gv[13],gv[14],gv[15]);
     y->n= 36;
     return(y);
 }

--- a/src/rkdb.c
+++ b/src/rkdb.c
@@ -81,7 +81,7 @@ SEXP kx_r_open_connection(SEXP whence) {
                   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buf, 256, NULL);
     error(buf);
 #else
-    error(strerror(errno));
+    error("%s",strerror(errno));
 #endif
   }
   return ScalarInteger(connection);


### PR DESCRIPTION
Could error with 
```
In file included from rkdb.c:15:
common.c: In function ‘guid_2_char’:
k.h:29:19: warning: pointer targets in passing argument 1 of ‘sprintf’ differ in signedness [-Wpointer-sign]
#define kG(x) ((x)->G0)
               ~~~~^~~~~
k.h:30:15: note: in expansion of macro ‘kG’
#define kC(x) kG(x)
               ^~
common.c:464:13: note: in expansion of macro ‘kC’
     sprintf(kC(y),"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",gv[ 0],gv[ 1],gv[ 2],gv[ 3],gv[ 4],gv[ 5],gv[ 6],gv[ 7],gv[ 8],gv[ 9],gv[10],gv[11],gv[12],gv[13],gv[14],gv[15]);
             ^~
In file included from /usr/include/features.h:438,
                 from /usr/include/errno.h:25,
                 from rkdb.c:5:
/usr/include/bits/stdio2.h:34:1: note: expected ‘char * restrict’ but argument is of type ‘G *’ {aka ‘unsigned char *’}
__NTH (sprintf (char *__restrict __s, const char *__restrict __fmt, ...))
^~~~~
rkdb.c: In function ‘kx_r_open_connection’:
rkdb.c:84:5: error: format not a string literal and no format arguments [-Werror=format-security]
     error(strerror(errno));
     ^~~~~
cc1: some warnings being treated as errors
make: *** [/usr/lib64/R/etc/Makeconf:202: rkdb.o] Error 1
ERROR: compilation failed for package ‘rkdb’
* removing ‘/local/twoolhead/R/rkdb’
Warning message:
In i.p(...) :
  installation of package ‘/tmp/RtmpCGEBzr/file3bc3c4de8e35e/rkdb_0.13.0.tar.gz’ had non-zero exit status
```